### PR TITLE
force Connection: close on outbound https requests

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -33,7 +33,8 @@ DucksboardNode.prototype._request = function(method, value, widgetId, callback) 
   var body = value ? JSON.stringify(value) : '';
 
   var headers = {
-    'Content-Length': body.length
+    'Content-Length': body.length,
+    'Connection': 'close'
   };
 
   if (method === 'POST') {


### PR DESCRIPTION
When sending > 5 outbound requests to ducksboard's API in rapid succession, it appears node ends up waiting for a socket (from its default pool of 5 allowed outbound to a single host).  Quick workaround is to force a Connection: close header onto the https call.  Will use more sockets but this is probably not an issue for most scripts sending data to ducksboard on a periodic basis.
